### PR TITLE
updating the role to allow multiple disks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,12 +54,15 @@
     --name {{ vm.name }} 
     --memory {{ vm.memory }} 
     --vcpus {{ vm.vcpus }} 
-    --disk size={{ vm.disk.size }},pool={{ vm.disk.pool }} 
+    {% for disk in vm.disks %} --disk boot_order={{ disk.boot_order }},size={{ disk.size }},pool={{ disk.pool }} {% endfor %}
     --network network={{ vm.network.name }} 
     --location {{ iso.location }}/{{ iso.name }} 
     --extra-args "ks=http://{{ host_ip }}/ks.cfg" 
     --os-type linux --noautoconsole
   become: yes
+
+#     --disk boot_order={{ vm.disks[0].boot_order }},size={{ vm.disks[0].size }},pool={{ vm.disks[0].pool }}
+
 
 - name: wait for the VM to build and be stopped
   virt:
@@ -91,7 +94,7 @@
 - name: get the disk location for the new VM
   become: yes
   shell: >
-    virsh domblklist {{ vm.name }} | awk '/qcow2/ {print $NF}'
+    virsh domblklist {{ vm.name }} | awk 'f{print $NF;f=0} /^-----/{f=1}'
   register: vm_disk
 
 - name: inject ssh key w/ virt-customize

--- a/templates/example-server.cfg.j2
+++ b/templates/example-server.cfg.j2
@@ -8,6 +8,20 @@ eula --agreed
 firstboot --disable
 logging --level=info
 
+
+%pre
+# capture the device name of the first drive so it doesn't have to be hardcoded
+set $(list-harddrives);
+d1=$1 # This is the device of disk 1
+cat <<DRIVES | /usr/bin/tee /tmp/drives
+ignoredisk --only-use=$d1
+bootloader --append=" crashkernel=auto" --location=mbr
+clearpart --all --initlabel
+autopart --type=thinp
+DRIVES
+%end
+
+
 # authentication
 auth  --useshadow  --passalgo=sha512
 firewall --enabled --service=ssh
@@ -23,9 +37,7 @@ network  --bootproto=static --device=ens3 --gateway={{ host_ip }} --nameserver={
 network --hostname={{ vm.name }}
 
 # disks
-bootloader --append=" crashkernel=auto" --location=mbr
-clearpart --all --initlabel
-autopart --type=lvm
+%include /tmp/drives # populated in pre section above
 
 %packages
 @core


### PR DESCRIPTION
A lot of this change requires a KS file that works appropriately...such as:

~~~bash
%pre
# capture the device name of the first drive so it doesn't have to be hardcoded
set $(list-harddrives);
d1=$1 # This is the device of disk 1
cat <<DRIVES | /usr/bin/tee /tmp/drives
ignoredisk --only-use=$d1
bootloader --append=" crashkernel=auto" --location=mbr
clearpart --all --initlabel
autopart --type=thinp
DRIVES
%end
...
# disks
%include /tmp/drives # populated in pre section above
~~~